### PR TITLE
Argument provided to 'amino' needs to be a copy.

### DIFF
--- a/src/bnb.js
+++ b/src/bnb.js
@@ -1,12 +1,29 @@
 const unMarshalBinaryLengthPrefixed = require('./utils/amino')
 const TYPE = require('./utils/types')
 
+function clone(obj) {
+    if(obj == null || typeof(obj) != 'object') {
+        return obj;
+    }
+    if(Buffer.isBuffer(obj)) {
+        return Buffer.from([])
+    }
+    var temp = new obj.constructor();
+    for(var key in obj) {
+        temp[key] = clone(obj[key]);
+    }
+    return temp;
+}
+
 /**
  * @param {string} hex
  * @param {string | class} type Transfer, placeOrder or cancelOrder
  */
 module.exports = function(hex, type) {
     if(typeof type === 'object') return unMarshalBinaryLengthPrefixed(Buffer.from(hex,'hex'), type).val
-    else if (TYPE.hasOwnProperty(type)) return unMarshalBinaryLengthPrefixed(Buffer.from(hex,'hex'), TYPE[type]).val
+    else if (TYPE.hasOwnProperty(type)) {
+        tempObject = clone(TYPE[type])
+return unMarshalBinaryLengthPrefixed(Buffer.from(hex,'hex'), tempObject).val
+    }
     else throw 'type should be one of the built-in types of passed in as object';
 }


### PR DESCRIPTION
The unmarshal method used in 'amino' package modifies its argument, so
the given argument needs to be a copy of the Type structure.